### PR TITLE
(portage-#24) Fix permissions of newly created files

### DIFF
--- a/lib/puppet/provider/portagefile.rb
+++ b/lib/puppet/provider/portagefile.rb
@@ -13,6 +13,7 @@ class Puppet::Provider::PortageFile < Puppet::Provider::ParsedFile
       Dir.mkdir(dir)
     end
     super
+    File.chmod(0644, target)
   end
 
   def self.build_line(hash, sym = nil)


### PR DESCRIPTION
this commit fixes the permissions of newly created files, but it does not fix the already added files by any of the package_\* types
