### PR TITLE
(portage-#29) Define portage::eselect for managing eselect modules

### DIFF
--- a/manifests/eselect.pp
+++ b/manifests/eselect.pp
@@ -1,0 +1,24 @@
+# = Define: portage::eselect
+#
+# Wrapper around eselect configuration tool
+#
+# == Parameters
+#
+# [*set*]
+#
+# The value of the eselect module
+#
+# == Example
+#
+#     portage::eselect { 'ruby':
+#       set => 'ruby19',
+#     }
+#
+define portage::eselect (
+  $set = undef,
+) {
+
+  exec { "eselect_${name}":
+    command => "/usr/bin/eselect ${name} set ${set}",
+  }
+}


### PR DESCRIPTION
I implemented it using a define. It could probably be better with a type/provider, but I''m not sure if it's worth it
