### PR TITLE
Permit numeric atoms in valid_atom?

### DIFF
--- a/lib/puppet/util/portage.rb
+++ b/lib/puppet/util/portage.rb
@@ -1,4 +1,14 @@
 module Puppet::Util::Portage
+  class << self
+    atom_prefix = '([<>=]|[<>]=)'
+    atom_name = '([a-zA-Z0-9-]+/[a-zA-Z0-9_+-]+?)'
+    atom_version = '(-[\d.]+[\w-]+)'
+
+    base_atom = Regexp.new("^#{atom_name}$")
+    versioned_atom = Regexp.new("^#{atom_prefix}#{atom_name}#{atom_version}$")
+    @@depend = Regexp.union(base_atom, versioned_atom)
+  end
+
   # Util methods for Portage types and providers.
 
   # Determine if a string is a valid DEPEND atom
@@ -10,15 +20,7 @@ module Puppet::Util::Portage
   #
   # @see http://www.linuxmanpages.com/man5/ebuild.5.php#lbAE 'man 5 ebuild section DEPEND'
   def self.valid_atom?(atom)
-    atom_prefix  = '(?:[<>=]|[<>]=)'
-    atom_name    = '(?:[a-zA-Z-]+/[a-zA-Z-][a-zA-Z0-9-]+?)'
-    atom_version = '(?:-[\d.]+[\w-]+)'
-
-    base_atom      = Regexp.new("^#{atom_name}$")
-    versioned_atom = Regexp.new("^#{atom_prefix}#{atom_name}#{atom_version}$")
-    depend         = Regexp.union(base_atom, versioned_atom)
-
     # Normalize the regular expression output to a boolean
-    !!(atom =~ depend)
+    !!(atom =~ @@depend)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,19 @@ RSpec.configure do |config|
   config.mock_with :mocha
 end
 
+##
+# This method loads system atoms under /usr/portage in an array.
+#
+# This is useful for fuzzy testing the atom validation and writing new test
+# cases.
+#
+def system_atoms
+  atoms = []
+
+  Dir.glob('/usr/portage/*/*').each do |dir|
+    next unless File.directory? dir
+    atoms << dir.split('/').slice(3,4).join('/')
+  end
+
+  atoms
+end

--- a/spec/unit/util/portage_spec.rb
+++ b/spec/unit/util/portage_spec.rb
@@ -4,11 +4,24 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "spec_hel
 describe Puppet::Util::Portage do
   describe "when validating atoms" do
 
-    valid_atoms   = %w{=sys-devel/gcc-4.3.2-r4 >=app-crypt/gnupg-1.9 net-analyzer/nagios-nrpe}
-    invalid_atoms = %w{sys-devel-gcc =sys-devel/gcc}
+    valid_atoms = [
+      '=foo/bar-1.0.0',
+      '>=foo/bar-1.0.0',
+      '<=foo/bar-1.0.0',
+      '>foo/bar-1.1.0',
+      '<foo/bar-1.0.0',
+      'foo1-bar2/messy_atom++',
+    ]
+
+    invalid_atoms = [
+      'sys-devel-gcc',
+      '=sys-devel/gcc',
+      # version without quantifier
+      'foo1-bar2/messy_atom++-1.0',
+    ]
 
     valid_atoms.each do |atom|
-      it "should accept #{atom} as a valid name" do
+      it "should accept '#{atom}' as a valid name" do
         Puppet::Util::Portage.valid_atom?(atom).should be_true
       end
     end


### PR DESCRIPTION
Was trying to keyword the dev-python/meld3 package and hit this.
