### PR TITLE
Default package_* to present

### DIFF
--- a/lib/puppet/type/package_keywords.rb
+++ b/lib/puppet/type/package_keywords.rb
@@ -7,7 +7,10 @@ Puppet::Type.newtype(:package_keywords) do
         target  => 'puppet',
       }"
 
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "The package name"

--- a/lib/puppet/type/package_mask.rb
+++ b/lib/puppet/type/package_mask.rb
@@ -6,7 +6,10 @@ Puppet::Type.newtype(:package_mask) do
         target  => 'chef',
       }"
 
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "The package name"

--- a/lib/puppet/type/package_unmask.rb
+++ b/lib/puppet/type/package_unmask.rb
@@ -6,7 +6,10 @@ Puppet::Type.newtype(:package_unmask) do
         target  => 'puppet',
       }"
 
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "The package name"

--- a/lib/puppet/type/package_use.rb
+++ b/lib/puppet/type/package_use.rb
@@ -7,7 +7,10 @@ Puppet::Type.newtype(:package_use) do
         target => 'puppet',
       }"
 
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "The package name"


### PR DESCRIPTION
Previously if the ensure value was not specified and no other properties
or parameters were given, package_\* entries would be treated as
unmanaged. This commit defaults the ensure to present for all package_
types.

This commit is based on 31b53b9738448c2d7844b0c0523b0315e3eb0b4e
It fixes #41 and causes no regression to #45
