### PR TITLE
Fix bug with rebuilding world set after touching make.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,15 +43,15 @@ class portage (
 
   exec { 'changed_makeconf_use':
     command     => '/usr/bin/emerge --changed-use @world',
-    require     => Concat[$make_conf],
     refreshonly => true,
     timeout     => 43200,
   }
 
   concat { $make_conf:
-    owner => root,
-    group => root,
-    mode  => 644,
+    owner  => root,
+    group  => root,
+    mode   => 644,
+    notify => Exec['changed_makeconf_use'],
   }
 
   concat::fragment { 'makeconf_header':


### PR DESCRIPTION
The regression was introduced in 0a21e6a where I removed the chain
from concat { $make_conf } while I should have removed it from
exec { 'changed_makeconf_use' }

fixes #48
