### PR TITLE
Initial commit of eselect type/provider

### DIFF
--- a/lib/puppet/provider/eselect/eselect.rb
+++ b/lib/puppet/provider/eselect/eselect.rb
@@ -1,0 +1,17 @@
+Puppet::Type.type(:eselect).provide(:eselect) do
+
+  commands :eselect => '/usr/bin/eselect'
+
+  def self.instances
+    output = Facter.to_hash.keep_if { |key, value| (key =~ /^eselect_.+/) }
+    output.map { |name, set| new(:name => name.sub(/^eselect_/, ''), :set => set) }
+  end
+
+  def set
+    Facter.value('eselect_' + resource[:name])
+  end
+
+  def set=(target)
+    eselect(resource[:name], 'set', target)
+  end
+end

--- a/lib/puppet/type/eselect.rb
+++ b/lib/puppet/type/eselect.rb
@@ -1,0 +1,10 @@
+Puppet::Type.newtype(:eselect) do
+
+  newparam(:name, :isnamevar => true) do
+    desc "The name of the eselect module."
+  end
+
+  newproperty(:set) do
+    desc "The value of the eselect module."
+  end
+end


### PR DESCRIPTION
It reads the equivalent fact in order to get the current state
Usage examples:

eselect { 'ruby':
  set => 'ruby19',
}

(In case of eselect sub-modules):

eselect { 'php_apache2':
  set => 'php5.3',
}

fixes #29
