### PR TITLE
Type and Provider for portage sets

### DIFF
--- a/lib/puppet/provider/package_set/package_set.rb
+++ b/lib/puppet/provider/package_set/package_set.rb
@@ -19,6 +19,9 @@ Puppet::Type.type(:package_set).provide(:package_set) do
     # Cross reference /var/lib/portage/world_sets with /etc/portage/sets/* to check if a set is installed.
     #
     # If it is loop through /etc/portage/sets/setname and verify all listed packages are installed.
+    if File.readlines('/var/lib/portage/world_sets').size == 0 then
+      return false
+    end
     File.readlines('/var/lib/portage/world_sets').each do | line |
       if line == "@#{resource[:name]}\n" then
         installed_packages = eix '--nocolor', '--pure-packages', '--stable', '--installed', '--format', '<category>/<name>\n'


### PR DESCRIPTION
As per the discussion in Issue #65, this type and provider allow you to install, upgrade, and remove portage sets. Feel free to reuse any of this code in the upstream provider if you think that is where this should be handled.
