### PR TITLE
Use @ prefix for variables in erb templates to fix deprecated syntax

### DIFF
--- a/templates/makeconf.conf.erb
+++ b/templates/makeconf.conf.erb
@@ -1,5 +1,5 @@
-<% if content == '' -%>
-<%= name %>
+<% if @content == '' -%>
+<%= @name %>
 <% else -%>
-<%= name.upcase %>="<%= [content].flatten.join(' ') %>"
+<%= @name.upcase %>="<%= [@content].flatten.join(' ') %>"
 <% end -%>

--- a/templates/postsync.sh.erb
+++ b/templates/postsync.sh.erb
@@ -1,3 +1,3 @@
 #!/bin/sh
-<%= content %>
+<%= @content %>
 :


### PR DESCRIPTION
Puppet variables used in erb templates should have the '@' prefix set, to separate them from local ruby variables. This change silences deprecation warnings on the puppetmaster, such as these : 

```
Variable access via 'content' is deprecated. Use '@content' instead. template[/etc/puppet/modules/portage/templates/makeconf.conf.erb]:1
    (at /etc/puppet/modules/portage/templates/makeconf.conf.erb:1:in `result')
Variable access via 'name' is deprecated. Use '@name' instead. template[/etc/puppet/modules/portage/templates/makeconf.conf.erb]:4
    (at /etc/puppet/modules/portage/templates/makeconf.conf.erb:4:in `result')

```
