### PR TITLE
http and ftp proxy variables should be lowercase

### DIFF
--- a/templates/makeconf.conf.erb
+++ b/templates/makeconf.conf.erb
@@ -1,5 +1,7 @@
 <% if @content == '' -%>
 <%= @name %>
+<% elsif @name == 'http_proxy' or @name == 'ftp_proxy' -%>
+<%= @name.downcase %>="<%= [@content].flatten.join(' ') %>"
 <% else -%>
 <%= @name.upcase %>="<%= [@content].flatten.join(' ') %>"
 <% end -%>


### PR DESCRIPTION
As per make.conf documentation, the only two variables that are
actually not uppercase, are "http_proxy" and "ftp_proxy.
