### PR TITLE
Relax concat dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,4 +4,4 @@ license 'GPLv2'
 summary 'Puppet types and providers for Gentoo portage'
 project_page 'https://github.com/gentoo/puppet-portage'
 
-dependency 'puppetlabs/concat', '1.0.x'
+dependency 'puppetlabs/concat', '=> 1.0.0'


### PR DESCRIPTION
This patch enables installation of this module from the forge without conflicting with newer, compatible versions of puppetlabs/concat.
