### PR TITLE
Set path on changed_makeconf_use exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class portage (
     refreshonly => true,
     timeout     => 43200,
     provider    => shell,
+    path        => ['/bin/, '/usr/bin', '/usr/local/bin'],
   }
 
   concat { $make_conf:


### PR DESCRIPTION
If there is no global path set, the exec command will fail, as sed is not found.
