### PR TITLE
Update Facter::Util::Resolution to Facter::Core::Execution for Facter…

### DIFF
--- a/lib/facter/util/portage.rb
+++ b/lib/facter/util/portage.rb
@@ -1,10 +1,9 @@
-require 'facter/util/resolution'
 module Facter::Util::Portage
   module_function
 
   # @return [Hash<Symbol, String>]
   def emerge_info
-    output = Facter::Util::Resolution.exec('emerge --info')
+    output = Facter::Core::Execution.exec('emerge --info')
 
     values = output.scan(/[0-9A-Z_]+=".+?"/)
 


### PR DESCRIPTION
This was required to get the portage.rb custom fact to run without error on a puppet run using Puppet 4.2 and Facter 3.0.1.

I think it should be compatible with Facter 2.4 but have not tested.