### PR TITLE
This require is no longer needed.

### DIFF
--- a/lib/facter/util/portage.rb
+++ b/lib/facter/util/portage.rb
@@ -1,4 +1,3 @@
-require 'facter/util/resolution'
 module Facter::Util::Portage
   module_function
 


### PR DESCRIPTION
Corrects a failure on Facter 3, where the ruby file paths aren't made
available and this require will crash. All APIs are made available
automatically, so this should be fine. This should also apply cleanly
to Facter 2, where this require is redundant.