### PR TITLE
Relax provider confines from operatingsystem to osfamily

### DIFF
--- a/lib/puppet/provider/eselect/eselect.rb
+++ b/lib/puppet/provider/eselect/eselect.rb
@@ -3,7 +3,7 @@ require 'puppet/util/eselect'
 
 Puppet::Type.type(:eselect).provide(:eselect) do
 
-  confine :operatingsystem => :gentoo
+  confine :osfamily => :gentoo
 
   commands Puppet::Util::Eselect::COMMANDS
 

--- a/lib/puppet/provider/layman/layman.rb
+++ b/lib/puppet/provider/layman/layman.rb
@@ -4,8 +4,8 @@ Puppet::Type.type(:layman).provide(:layman) do
 
   commands :layman => '/usr/bin/layman'
 
-  confine :operatingsystem => :gentoo
-  defaultfor :operatingsystem => :gentoo
+  confine :osfamily => :gentoo
+  defaultfor :osfamily => :gentoo
 
   def self.instances
     overlays.collect do |name|

--- a/lib/puppet/provider/webapp/webapp.rb
+++ b/lib/puppet/provider/webapp/webapp.rb
@@ -7,8 +7,8 @@ Puppet::Type.type(:webapp).provide(:webapp) do
 
   commands :webapp_config => '/usr/sbin/webapp-config'
 
-  confine :operatingsystem => :gentoo
-  defaultfor :operatingsystem => :gentoo
+  confine :osfamily => :gentoo
+  defaultfor :osfamily => :gentoo
 
   mk_resource_methods
 


### PR DESCRIPTION
Relaxes the provider confines for eselect, layman and webapp types to run on other Gentoo-like distributions, matching on osfamily rather than operatingsystem.

Fixes gentoo/puppet-portage#157