### PR TITLE
(BUGFIX) Replace validate_re() with assert_type()

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -133,8 +133,7 @@ define portage::package (
     $_portage_emerge_command = undef
   }
   $_emerge_command = pick($emerge_command, $_portage_emerge_command, $portage::params::emerge_command)
-  validate_re($_emerge_command, '^/', 'emerge_command must start with an absolute path')
-
+  assert_type(Stdlib::Unixpath, $_emerge_command) # emerge_command must start with an absolute path
   $atom = $ensure ? {
     /(present|absent|purged|held|installed|latest)/ => $name,
     /./ => "=${name}-${ensure}",


### PR DESCRIPTION
As of the newest version of puppetlabs-stdlib validate_re and many other similar functions have been fully removed from the codebase after having been deprecated for some time.
As such it is necessary to use the built in assert_type command in its place.
Have chosen to use `Stdlib::Unixpath` over `Stdlib::Absolutepath` as this module does not support windows.